### PR TITLE
check the msg_id field instead of the Resultsdb ID when pushing from CentOS to Fedora

### DIFF
--- a/rdbsync/__init__.py
+++ b/rdbsync/__init__.py
@@ -24,6 +24,7 @@ FEDORA_URL_HELP = 'The URL to the Fedora ResultsDB API. Default: {}'.format(FEDO
 POLL_INTERVAL_HELP = ('If provided, the command will run continuously, sleeping for the'
                       ' provided number of seconds after each run.')
 LOG_LEVEL_HELP = 'The log level to use. Options are DEBUG, INFO, WARNING, ERROR, CRITICAL.'
+DRY_RUN_HELP = 'Dry run. If selected, print what would have been added to Fedora ResultsDB.'
 
 
 @click.group()
@@ -111,7 +112,8 @@ def verify(centos_url, fedora_url, timeout, log_level):
               help='The timeout for HTTP requests in seconds. Default: 15')
 @click.option('--poll-interval', default=None, type=int, help=POLL_INTERVAL_HELP)
 @click.option('--log-level', default='INFO', type=str, help=LOG_LEVEL_HELP)
-def run(centos_url, fedora_url, token_file, timeout, poll_interval, log_level):
+@click.option('--dry-run', default=False, is_flag=True, help=DRY_RUN_HELP)
+def run(centos_url, fedora_url, token_file, timeout, poll_interval, log_level, dry_run):
     """Synchronize the CentOS CI ResultsDB to the Fedora ResultsDB."""
 
     logging.basicConfig(

--- a/rdbsync/__init__.py
+++ b/rdbsync/__init__.py
@@ -152,9 +152,9 @@ def run(centos_url, fedora_url, token_file, timeout, poll_interval, log_level, d
             # Grab a list of duplicate message ids - if some of the results
             #  already exist in ResultsDB, we want to skip those to avoid
             #  storing duplicates
-            centos_result_ids = ','.join([str(r['data']['msg_id']) for r in centos_results_page])
+            centos_msg_ids = ','.join([str(r['data']['msg_id']) for r in centos_results_page])
             existing_fedora_results = next(fedora_resultsdb.get_results(
-                msg_id=centos_result_ids, limit=50))
+                msg_id=centos_msg_ids, limit=50))
             duplicate_ids = [r['data']['msg_id'][0]
                              for r in existing_fedora_results]
             for result in centos_results_page:


### PR DESCRIPTION
Primarily we want to check the message IDs. To make this happen I also had to add a dry-run check because I didn't want to (and couldn't without a token) actually modify anything in Fedora ResultsDB